### PR TITLE
adding whisper-large-v3 as an available model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,26 @@ uv run python src/transcribe_audio.py [OPTIONS]
 
 ### Available Models
 
+### Adding New Models
+
+All models are defined in `src/transcribe_audio.py` under the `AVAILABLE_MODELS` dictionary. You can add new models by following the existing format.
+
+```python
+AVAILABLE_MODELS = {
+    "new-model-tagname": { # e.g., "whisper-small"
+        "id": "source/new-model-id",  # HuggingFace model ID
+        "type": "sourcetype",  # e.g. "whisper" or "voxtral"
+        "description": "short description of the model",  # e.g., "Fast Whisper model, good accuracy"
+    },
+    "whisper-tiny": {
+        "id": "openai/whisper-tiny",
+        "type": "whisper",
+        "description": "Fastest Whisper model, least accurate (~39 MB)",
+    },
+}
+
+```
+
 #### Whisper Models (OpenAI)
 
 Choose from different Whisper models based on your speed vs accuracy needs:
@@ -50,9 +70,10 @@ Choose from different Whisper models based on your speed vs accuracy needs:
 | Model | Description | Size | Use Case |
 |-------|-------------|------|----------|
 | `whisper-tiny` | Fastest model, least accurate | ~39 MB | Quick testing, real-time |
-| `whisper-small` | Fast model, good accuracy | ~244 MB | **Recommended default** |
+| `whisper-small` | Fast model, good accuracy | ~244 MB | **Recommended default for testing** |
 | `whisper-medium` | Balanced speed/accuracy | ~769 MB | High-quality transcription |
-| `whisper-large-v3-turbo` | Best accuracy, slower | ~1550 MB | Maximum quality needed |
+| `whisper-large-v3-turbo` | Best accuracy, slower | ~1550 MB | Best accuracy/speed tradeoff **Recommended default for project transcription** |
+| `whisper-large-v3` | Best accuracy, much slower | ~1550 MB | Maximum quality needed |
 
 **Whisper Language Support**: Supports 99 languages including English, Spanish, French, German, Chinese, Japanese, Korean, Arabic, Hindi, and many more. Use ISO 639-1 language codes (e.g., `en`, `es`, `fr`, `de`, `zh`, `ja`, `ko`, `ar`, `hi`).
 

--- a/src/transcribe_audio.py
+++ b/src/transcribe_audio.py
@@ -68,6 +68,11 @@ AVAILABLE_MODELS = {
         "type": "whisper",
         "description": "Best Whisper accuracy, slower (~1550 MB)",
     },
+    "whisper-large-v3": {
+        "id": "openai/whisper-large-v3",
+        "type": "whisper",
+        "description": "Best Whisper accuracy, much slower",
+    },
 }
 
 # Add Voxtral models if available
@@ -494,6 +499,7 @@ Examples:
   python src/transcribe_audio.py --model whisper-tiny --format csv
   python src/transcribe_audio.py --model voxtral-mini --format json
   python src/transcribe_audio.py --model whisper-large-v3-turbo --format duckdb --all-audio
+  python src/transcribe_audio.py --model whisper-large-v3 --format duckdb --all-audio --language en
   python src/transcribe_audio.py --model voxtral-small --format parquet
   python src/transcribe_audio.py --input-path /path/to/audio --output-path /path/to/output
   python src/transcribe_audio.py --input-path ~/recordings --output-path ~/results --model whisper-medium


### PR DESCRIPTION
# Pull Request Summary 🚀

## What does this PR do? 📝

<!-- A clear and concise description of the changes introduced in this pull request -->

Add the Large Whisper model as an option for transcription models.

Adding instructions about how to include new available models.

## Why is this change needed? 🤔

<!-- Describe the motivation or context for this pull request -->

In addition to the smaller Whisper models, we want access to Whisper Large V3, (the turbo version was already included in the script).

## How was this implemented? 🛠️

<!-- Explain the approach and implementation details -->

updated the AVAILABLE_MODELS section of `src/transcribe_audio.py` with the HUgging Face models for `whisper-large-v3`

## How to test or reproduce? 🧪

<!-- Provide steps to test or reproduce the changes -->

there are two audio files in `tests/assets/audio` you can use them to tests transcription input and output.

Use the following with `whisper-tiny` output is terrible but it's fast for testing:

`uv run src/transcribe_audio.py  uv run python src/transcribe_audio.py --input-path tests/assets/audio/ --output-path output/ --model whisper-tiny --format csv`

Then use `whisper-large-v3` (warning this may be slow to download the model and to run) *Do not run unless you have ample bandwidth and memory. note the `--all-audio` ensures that the transcriptions are re-run which is important if you previously ran transcription with other models.

`uv run src/transcribe_audio.py  uv run python src/transcribe_audio.py --input-path tests/assets/audio/ --output-path output/ --model whisper-large-v3 --format csv --all-audio`

## Screenshots (if applicable) 📷

<!-- Add relevant screenshots or GIFs to illustrate the changes -->

## Checklist ✅

- [X] I have run and tested my changes locally
- [X] I have limited this PR to less than 1000 lines of code change (if not, explain why)
- [ ] I have updated/added tests to cover my changes (if applicable)
- [ ] I have updated/added requirements to cover my changes (if applicable)
- [ ] I have run linting and formatting on any code changes (if applicable)
- [X] I have updated the documentation (README, etc.) accordingly

## Reviewer Emoji Legend

|     |         `:code:`          | Meaning                                                                                                                                                                                                                                         |
| :-: | :-----------------------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 😃👍💯 | `:smiley:` `:+1:` `:100:` | I like this... <br /><br /> ...and I want the author to know it! This is a way to highlight positive parts of a code review.                                                                                                                    |
| ⭐⭐⭐ |  `:star: :star: :star:`   | Important to fix before PR can be approved... <br /><br /> And I am providing reasons why it needs to be addressed as well as suggested improvements.                                                                                           |
| ⭐⭐  |      `:star: :star:`      | Important to fix but non-blocking for PR approval... <br /><br /> And I am providing suggestions where it could be improved either in this PR or later.                                                                                         |
|  ⭐  |         `:star:`          | Give this some thought but non-blocking for PR approval... <br /><br /> ...and consider this a suggestion, not a requirement.                                                                                                                   |
|  ❓  |       `:question:`        | I have a question. <br /><br /> This should be a fully formed question with sufficient information and context that requires a response.                                                                                                        |
|  📝  |         `:memo:`          | This is an explanatory note, fun fact, or relevant commentary that does not require any action.                                                                                                                                                 |
|  ⛏  |         `:pick:`          | This is a nitpick. <br /><br /> This does not require any changes and is often better left unsaid. This may include stylistic, formatting, or organization suggestions and should likely be prevented/enforced by linting if they really matter |
| ♻️  |        `:recycle:`        | Suggestion for refactoring. <br /><br /> Should include enough context to be actionable and not be considered a nitpick.                                                                                                                        |
